### PR TITLE
kinda hotfix?

### DIFF
--- a/src/api/WebsocketHelper.tsx
+++ b/src/api/WebsocketHelper.tsx
@@ -100,6 +100,11 @@ function initWebsocket(): void {
             return;
         }
 
+        if(request?.type === RequestType.SET_GOOGLE && (e.target as any).url === tempOldWebsocket.url){
+            removeSentRequests([request]);
+            return;
+        }
+
         if (request) {
             _handleRequestOnMessage(response, request);
         }
@@ -172,7 +177,7 @@ function sendRequest(request: ApiRequest): Promise<void> {
             }
 
             if (request.type === RequestType.SET_GOOGLE) {
-                tempOldWebsocket.send(JSON.stringify(request));
+               tempOldWebsocket.send(JSON.stringify(request));
             }
 
         } else {


### PR DESCRIPTION
This fixes the issue that a successful setGoogle-Response of the tempWebsocket triggers the success-Function of the "normal" websocket.

It still doesnt seem to work properly though. @Ekwav we need to talk about this, where the issue could be asap