### PR TITLE
use percice time returned

### DIFF
--- a/components/Flipper/Flipper.tsx
+++ b/components/Flipper/Flipper.tsx
@@ -224,7 +224,7 @@ function Flipper(props: Props) {
     function getLastFlipFetchTime() {
         setLastFlipFetchTimeLoading(true)
         api.getFlipUpdateTime().then(date => {
-            setLastFlipFetchTimeSeconds((date.getSeconds() + 10) % 60)
+            setLastFlipFetchTimeSeconds((date.getSeconds()) % 60)
             setLastFlipFetchTimeLoading(false)
         })
     }


### PR DESCRIPTION
I unified the time to be calculated not based on the time hypixel says but the time I actually was able to load new auctions.
This should fix any out of sync issues that were reported