### PR TITLE
remove lazy loading for search

### DIFF
--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -144,7 +144,6 @@ function Search(props: Props) {
                     height="32"
                     alt=""
                     style={{ marginRight: '10px' }}
-                    loading="lazy"
                 />
                 {props.selected.name || convertTagToName((props.selected as Item).tag)}
             </h1>
@@ -275,7 +274,6 @@ function Search(props: Props) {
                                       width={32}
                                       src={result.dataItem.iconUrl}
                                       alt=""
-                                      loading="lazy"
                                   />
                               ) : (
                                   <Spinner animation="border" role="status" variant="primary" />

--- a/pages/player/[uuid]/flips/[flipUid].tsx
+++ b/pages/player/[uuid]/flips/[flipUid].tsx
@@ -49,7 +49,6 @@ function Flipper(props: Props) {
                                 height="32"
                                 alt=""
                                 style={{ marginRight: '10px' }}
-                                loading="lazy"
                             />
                             <span>{player.name}</span>
                         </p>

--- a/pages/player/[uuid]/flips/index.tsx
+++ b/pages/player/[uuid]/flips/index.tsx
@@ -83,7 +83,6 @@ function Flipper(props: Props) {
                                 height="32"
                                 alt=""
                                 style={{ marginRight: '10px' }}
-                                loading="lazy"
                             />
                             <span>{player.name}</span>
                         </p>

--- a/pages/player/[uuid]/index.tsx
+++ b/pages/player/[uuid]/index.tsx
@@ -126,7 +126,6 @@ function PlayerDetails(props: Props) {
                                 height="32"
                                 alt=""
                                 style={{ marginRight: '10px' }}
-                                loading="lazy"
                             />
                             <span>{selectedPlayer?.name}</span>
                             {claimAccountElement}


### PR DESCRIPTION
I want to remove the lazy loading for the search.
Sometimes it takes too long until the browser loads the images of the search, resulting in a search that looks "broken" or "slow".

It looks much better that way :)