### PR TITLE
Addressing "Bids don't refresh when navigating" (#864)

### DIFF
--- a/components/PlayerDetailsList/PlayerDetailsList.tsx
+++ b/components/PlayerDetailsList/PlayerDetailsList.tsx
@@ -14,9 +14,9 @@ import styles from './PlayerDetailsList.module.css'
 
 interface Props {
     playerUUID: string
+    playerName: string
     loadingDataFunction: Function
     type: 'auctions' | 'bids'
-    auctions?: Auction[]
 }
 
 interface ListState {
@@ -43,51 +43,44 @@ function PlayerDetailsList(props: Props) {
     let isLoadingElements = useRef(false)
 
     useEffect(() => {
+
         mounted = true
         router.events.on('routeChangeStart', onRouteChange)
 
+        setPlayerName(props.playerName)
+
         let listState = getListState()
-        if (listState !== undefined) {
+        if (listState) {
             setListElements(listState.listElements)
             setAllElementsLoaded(listState.allElementsLoaded)
-            setTimeout(() => {
-                if (!mounted) {
-                    return
-                }
-                window.scrollTo({
-                    left: 0,
-                    top: listState!.yOffset,
-                    behavior: 'auto'
-                })
-            }, 100)
+            isLoadingElements.current = false
         }
+        else {
+            // We need to set reset to true to remove the previous player's listElements
+            loadNewElements(true)
+        }
+
+        setTimeout(() => {
+            if (!mounted) {
+                return
+            }
+            window.scrollTo({
+                left: 0,
+                top: listState!.yOffset,
+                behavior: 'auto'
+            })
+        }, 100)
 
         return () => {
             mounted = false
             router.events.off('routeChangeStart', onRouteChange)
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
 
-    useEffect(() => {
-        api.getPlayerName(props.playerUUID).then(name => {
-            if (!mounted) {
-                return
-            }
-            setPlayerName(name)
-            setPlayerName(name)
-            setListElements(props.auctions || [])
-            setAllElementsLoaded(props.auctions ? props.auctions.length < 12 : false)
-        })
     }, [props.playerUUID])
 
-    useEffect(() => {
-        if (!props.auctions) {
-            loadNewElements()
-        }
-    }, [props.auctions])
 
     let onRouteChange = () => {
+        console.log("list States", listStates)
         let listState = getListState()
         if (listState) {
             listState.yOffset = window.pageYOffset

--- a/components/PlayerDetailsList/PlayerDetailsList.tsx
+++ b/components/PlayerDetailsList/PlayerDetailsList.tsx
@@ -37,9 +37,9 @@ function PlayerDetailsList(props: Props) {
     let forceUpdate = useForceUpdate()
     let router = useRouter()
 
-    let [listElements, setListElements] = useState<(Auction | BidForList)[]>(props.auctions || [])
-    let [allElementsLoaded, setAllElementsLoaded] = useState(props.auctions ? props.auctions.length < 12 : false)
-    let [playerName, setPlayerName] = useState('')
+    let [listElements, setListElements] = useState<(Auction | BidForList)[]>([])
+    let [allElementsLoaded, setAllElementsLoaded] = useState<boolean>()
+    let [playerName, setPlayerName] = useState<string>('')
     let isLoadingElements = useRef(false)
 
     useEffect(() => {
@@ -75,6 +75,9 @@ function PlayerDetailsList(props: Props) {
                 return
             }
             setPlayerName(name)
+            setPlayerName(name)
+            setListElements(props.auctions || [])
+            setAllElementsLoaded(props.auctions ? props.auctions.length < 12 : false)
         })
     }, [props.playerUUID])
 


### PR DESCRIPTION
### Issue

Currently, the bids and auctions sections don't change when searching between players. After switching to another player, old data for the previous player is kept on screen and new data isn't immediately loaded in.
More info in: https://github.com/Coflnet/hypixel-react/issues/864

### Solution

The issue seems to have come from the fact that `PlayerDetailsList` doesn't unmount and remount when searching between players. When searching between players,`detailType` remains unchanged causing change detection to not unmount `PlayerDetailsList` (https://github.com/Coflnet/hypixel-react/blob/develop/pages/player/%5Buuid%5D/index.tsx#L169-L176). This causes `useState` to not reinitialize `listElements` (https://github.com/Coflnet/hypixel-react/blob/develop/components/PlayerDetailsList/PlayerDetailsList.tsx#L40).

One solution can be to create a `useEffect` to call `setListElements` and some other fns whenever `props.UUID` changes

### Testing

NA

### Additional Notes

I also noticed that onRouteChange only has access to the initial value of `props`. I believe this is caused because `router.events.on('routeChangeStart', onRouteChange)` is only called once due to the empty second parameter of `useEffect`.(https://github.com/Coflnet/hypixel-react/blob/develop/components/PlayerDetailsList/PlayerDetailsList.tsx#L47-L70) This causes the event-listener to only call the onRouteChange  with the initial value of `props`.

More info [here](https://stackoverflow.com/questions/59881386/why-does-the-callback-on-addevenetlistener-print-out-old-state): 

In addition, I also felt that it would be better to remove auctions from the props of `PlayerDetailsList` and instead query and cache all of the player data within listStates. This is just to have a more consistent source of data. However, I'm not fully aware of optimizations that next.js uses so this could be a bad choice.

This PR also addressed thos eissues